### PR TITLE
refactor(Makefile): update chainsaw setup and Helm targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,13 +361,14 @@ ifneq ($(strip $(HELM_DEPENDS)),)
 	done
 endif
 
-.PHONY: helm-install
-helm-install: helm-install-depends ## Install the helm chart.
-	$(HELM) upgrade --install --create-namespace --namespace $(TEST_NAMESPACE) --wait $(PROJECT_NAME) kubedoop/$(PROJECT_NAME) --version $(VERSION)
-
-.PHONY: helm-uninstall
-helm-uninstall: ## Uninstall the helm chart.
-	$(HELM) uninstall --namespace $(TEST_NAMESPACE) $(PROJECT_NAME)
+## helm uninstall depends
+.PHONY: helm-uninstall-depends
+helm-uninstall-depends: ## Uninstall the helm chart depends.
+ifneq ($(strip $(HELM_DEPENDS)),)
+	for dep in $(HELM_DEPENDS); do \
+		$(HELM) uninstall --namespace $(TEST_NAMESPACE) $$dep; \
+	done
+endif
 
 # kind
 KIND_VERSION ?= v0.24.0
@@ -436,7 +437,8 @@ $(CHAINSAW): $(LOCALBIN)
 chainsaw-setup: ## Run the chainsaw setup
 	make docker-build
 	$(KIND) --name $(KIND_CLUSTER_NAME) load docker-image $(IMG)
-	KUBECONFIG=$(KIND_KUBECONFIG) make helm-install
+	KUBECONFIG=$(KIND_KUBECONFIG) make helm-install-depends
+	KUBECONFIG=$(KIND_KUBECONFIG) make deploy
 
 .PHONY: chainsaw-test
 chainsaw-test: chainsaw ## Run the chainsaw test
@@ -444,4 +446,5 @@ chainsaw-test: chainsaw ## Run the chainsaw test
 
 .PHONY: chainsaw-cleanup
 chainsaw-cleanup: ## Run the chainsaw cleanup
-	KUBECONFIG=$(KIND_KUBECONFIG) make helm-uninstall
+	KUBECONFIG=$(KIND_KUBECONFIG) make helm-uninstall-depends
+	KUBECONFIG=$(KIND_KUBECONFIG) make undeploy


### PR DESCRIPTION
Description:
This PR refactors the Helm targets and updates the chainsaw setup in the Makefile. The changes include:

- Removed helm-install and helm-uninstall targets.
- Updated chainsaw-setup target to use helm-install-depends instead of helm-install.

Purpose:
1. Refactor chainsaw test to rely on the helm-install-depends task for better modularity and dependency management.
2. Ensure the current operator uses the deploy task for deployment, aligning with the updated setup process.

These changes improve the modularity, clarity, and maintainability of the Makefile, making it easier to manage Helm dependencies and the chainsaw setup process.
