### PR TITLE
chore: upgrade golangci-lint to v2.12.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.5.0
+GOLANGCI_LINT_VERSION ?= v2.12.1
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/internal/controller/historyserver/constants.go
+++ b/internal/controller/historyserver/constants.go
@@ -1,5 +1,6 @@
 package historyserver
 
 const (
-	trueValue = "true"
+	trueValue     = "true"
+	defaultScheme = "http"
 )

--- a/internal/controller/historyserver/s3.go
+++ b/internal/controller/historyserver/s3.go
@@ -68,7 +68,7 @@ func GetInlineS3Bucket(ctx context.Context, client *client.Client, s3Bucket *v1a
 	}
 
 	endpoint := url.URL{
-		Scheme: "http",
+		Scheme: defaultScheme,
 		Host:   s3ConnectionSpec.Host,
 	}
 	if s3ConnectionSpec.Port != 0 {

--- a/internal/controller/historyserver/service.go
+++ b/internal/controller/historyserver/service.go
@@ -32,7 +32,7 @@ func NewRoleGroupMetricsService(
 	// Create service name with -metrics suffix
 	serviceName := util.GetMetricsServiceName(roleGroupInfo)
 
-	scheme := "http"
+	scheme := defaultScheme
 	// Prepare labels (copy from roleGroupInfo and add metrics labels)
 	labels := make(map[string]string)
 	for k, v := range roleGroupInfo.GetLabels() {

--- a/internal/controller/historyserver/statefulset.go
+++ b/internal/controller/historyserver/statefulset.go
@@ -232,7 +232,7 @@ func (b *StatefulSetBuilder) getOidcContainer(ctx context.Context) (*corev1.Cont
 	}
 
 	issuer := url.URL{
-		Scheme: "http",
+		Scheme: defaultScheme,
 		Host:   oidcProvider.Hostname,
 		Path:   oidcProvider.RootPath,
 	}
@@ -259,7 +259,7 @@ func (b *StatefulSetBuilder) getOidcContainer(ctx context.Context) (*corev1.Cont
 	var sparkHistoryPorts int32
 
 	for _, port := range b.Ports {
-		if port.Name == "http" {
+		if port.Name == util.HttpPortName {
 			sparkHistoryPorts = port.ContainerPort
 			break
 		}


### PR DESCRIPTION
## Summary

Upgrade golangci-lint from v2.5.0 to v2.12.1.

## Changes

- Updated `GOLANGCI_LINT_VERSION` in Makefile to v2.12.1

## Known remaining issues

After running `make lint-fix`, there are 3 `goconst` issues that cannot be auto-fixed:

- `internal/controller/historyserver/s3.go:71` - string "http" has 4 occurrences, make it a constant
- `internal/controller/historyserver/service.go:35` - string "http" has 4 occurrences, make it a constant
- `internal/controller/historyserver/statefulset.go:235` - string "http" has 4 occurrences, make it a constant

These should be addressed in a follow-up PR.