### PR TITLE
fix: add --config to chainsaw test in release and chart-lint-test workflows

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -131,4 +131,4 @@ jobs:
 
           # E2E tests
           make chainsaw
-          ./bin/chainsaw test --test-dir ./test/e2e/
+          ./bin/chainsaw test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,7 +329,7 @@ jobs:
 
           # E2E tests
           make chainsaw
-          ./bin/chainsaw test --test-dir ./test/e2e/
+          ./bin/chainsaw test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
 
 
   release-chart:


### PR DESCRIPTION
## Problem

Both `release.yml` and `chart-lint-test.yml` were missing `--config`, causing chainsaw to use **default timeouts (AssertTimeout 30s)** instead of the configured values in `.chainsaw.yaml` (assert: 120s). Heavy services like Spark need >30s to start, causing **false timeout failures**.

This was discovered during the hive-operator 0.4.0-dev release: <https://github.com/zncdatadev/hive-operator/pull/327>

## Fix

Add `--config ./test/e2e/.chainsaw.yaml` to chainsaw test commands in both workflows.

## Note

Unlike other operators where only release.yml was missing `--config`, spark-k8s-operator had it missing in both release.yml and chart-lint-test.yml.