### PR TITLE
fix(ci): split chart-lint-test into chart-lint-helm and chart-e2e

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -43,33 +43,33 @@ jobs:
       options: --user 1001
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Run ah lint
         working-directory: deploy/helm
         run: ah lint
 
-  lint-test:
+  chart-lint-helm:
     runs-on: ubuntu-latest
     needs:
       - check-crds-sync
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4.3.1
+        uses: azure/setup-helm@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
           check-latest: true
 
       - name: Setup Chart Linting
         id: lint
-        uses: helm/chart-testing-action@v2.7.0
+        uses: helm/chart-testing-action@v2.8.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -85,50 +85,39 @@ jobs:
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@v1.14.0
+
+      - name: Setup Go
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: actions/setup-go@v6
         with:
-          cluster_name: kind  # Default cluster name is 'chart-testing'
+          go-version-file: go.mod
+
+      - name: Build image
+        if: steps.list-changed.outputs.changed == 'true'
+        run: make docker-build
 
       - name: Load images to cluster
         if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          make docker-build
-          kind load docker-image quay.io/zncdatadev/spark-k8s-operator:$VERSION
-
+        run: kind load docker-image --name chart-testing quay.io/zncdatadev/spark-k8s-operator:$VERSION
 
       - name: Run chart-testing (install)
-        id: ct-test
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install --config ./.github/configs/ct-install.yaml
-          # Save success result to github output
-          if [[ $? -eq 0 ]]; then
-            echo "ct_tested=true" >> "$GITHUB_OUTPUT"
-          fi
 
-      - name: Build helm chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          make helm-chart-package
+  chart-e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
 
-      - name: Run e2e with chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          HELM_DEPENDENCIES=(
-            commons-operator
-            listener-operator
-            secret-operator
-            zookeeper-operator
-          )
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
-          # Install dependencies
-          for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
-          done
-
-          # Install packaged operator chart
-          helm install --create-namespace --namespace spark-k8s-operator --wait spark-k8s-operator ./target/charts/spark-k8s-operator-$VERSION.tgz
-
-          # E2E tests
-          make chainsaw
-          ./bin/chainsaw test --test-dir ./test/e2e/
+      - name: Run chart-e2e
+        run: make chart-e2e

--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -119,5 +119,12 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Create KinD cluster
+        env:
+          CHAINSAW_KUBECONFIG: kind-kubeconfig-chart-e2e
+        run: make setup-chainsaw-cluster
+
       - name: Run chart-e2e
+        env:
+          CHAINSAW_KUBECONFIG: kind-kubeconfig-chart-e2e
         run: make chart-e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,7 +326,14 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Create KinD cluster
+        env:
+          CHAINSAW_KUBECONFIG: kind-kubeconfig-chart-e2e
+        run: make setup-chainsaw-cluster
+
       - name: Run chart-e2e
+        env:
+          CHAINSAW_KUBECONFIG: kind-kubeconfig-chart-e2e
         run: make chart-e2e
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v20
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -73,10 +73,10 @@ jobs:
         product-version: ['3.5.2','3.5.5']
     steps:
       - name: Clone the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -113,7 +113,7 @@ jobs:
       - chainsaw-e2e
     steps:
       - name: Clone the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Cosign
         uses: sigstore/cosign-installer@main
@@ -127,7 +127,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Login to quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -173,27 +173,27 @@ jobs:
       options: --user 1001
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Run ah lint
         working-directory: deploy/helm
         run: ah lint
 
 
-  chart-lint-test:
+  chart-lint-helm:
     runs-on: ubuntu-latest
     needs:
       - check-crds-sync
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4.3.0
+        uses: azure/setup-helm@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
           check-latest: true
@@ -209,8 +209,16 @@ jobs:
         id: commit-range
         run: |
           # Get current and previous tag
+          # Exclude -dev pre-release tags only when looking for the previous tag,
+          # not when matching the current tag itself
           CURRENT_TAG="${{ github.ref_name }}"
-          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1 | grep -v '\\-dev$')
+
+          # If the -dev tag itself was the only match (no previous stable tag found),
+          # try again excluding -dev to find the actual previous stable release
+          if [[ -z "$PREVIOUS_TAG" ]]; then
+            PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -v '\\-dev$' | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
+          fi
 
           # First release detection
           if [[ "$PREVIOUS_TAG" == "$CURRENT_TAG" || -z "$PREVIOUS_TAG" ]]; then
@@ -281,55 +289,45 @@ jobs:
 
       - name: Create kind cluster
         if: steps.check-changes.outputs.changed == 'true'
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@v1.14.0
+
+      - name: Setup Go
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: actions/setup-go@v6
         with:
-          cluster_name: kind  # Default cluster name is 'chart-testing'
+          go-version-file: go.mod
+
+      - name: Build image
+        if: steps.check-changes.outputs.changed == 'true'
+        run: make docker-build
 
       - name: Load images to cluster
         if: steps.check-changes.outputs.changed == 'true'
-        run: |
-          make docker-build
-          kind load docker-image quay.io/zncdatadev/spark-k8s-operator:$VERSION
+        run: kind load docker-image --name chart-testing quay.io/zncdatadev/spark-k8s-operator:$VERSION
 
       - name: Run chart-testing (install)
-        id: ct-test
         if: steps.check-changes.outputs.changed == 'true'
         run: |
           ct install \
             --since "${{ steps.commit-range.outputs.since_commit }}" \
             --target-branch "${{ steps.commit-range.outputs.target_branch }}" \
             --config ./.github/configs/ct-install.yaml
-          # Save success result to github output
-          if [[ $? -eq 0 ]]; then
-            echo "ct_tested=true" >> "$GITHUB_OUTPUT"
-          fi
 
-      - name: Build helm chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          make helm-chart-package
+  chart-e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
 
-      - name: Run e2e with chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          HELM_DEPENDENCIES=(
-            commons-operator
-            listener-operator
-            secret-operator
-            zookeeper-operator
-          )
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
-          # Install dependencies
-          for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
-          done
-
-          # Install packaged operator chart
-          helm install --create-namespace --namespace spark-k8s-operators --wait spark-k8s-operator ./target/charts/spark-k8s-operator-$VERSION.tgz
-
-          # E2E tests
-          make chainsaw
-          ./bin/chainsaw test --test-dir ./test/e2e/
+      - name: Run chart-e2e
+        run: make chart-e2e
 
 
   release-chart:
@@ -338,13 +336,14 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - chart-linter-artifacthub
-      - chart-lint-test
+      - chart-lint-helm
+      - chart-e2e
     steps:
       - name: Clone the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Login to quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_CHART_USERNAME }}
@@ -355,7 +354,7 @@ jobs:
           make helm-chart-publish
 
       - name: Clone helm charts repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: zncdatadev/kubedoop-helm-charts
           ref: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ cover.out
 # helm charts
 # helm package directory
 target
+.worktree/

--- a/Makefile
+++ b/Makefile
@@ -343,6 +343,21 @@ setup-chainsaw-e2e: chainsaw docker-build ## Run the chainsaw setup
 chainsaw-e2e: ## Run the chainsaw e2e tests
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
 
+.PHONY: chart-e2e
+chart-e2e: ## Run chart e2e tests (deploy via Helm, then run chainsaw)
+	@echo "Building Helm chart..."
+	$(MAKE) helm-chart-package
+	@echo "Installing operator dependencies..."
+	@if [ -n "$(strip $(OPERATOR_DEPENDS))" ]; then \
+		for dep in $(OPERATOR_DEPENDS); do \
+			"$(HELM)" upgrade --install --create-namespace --namespace kubedoop-operators --wait $$dep oci://quay.io/kubedoopcharts/$$dep --version $$(VERSION); \
+		done; \
+	fi
+	@echo "Installing spark-k8s-operator chart..."
+	"$(HELM)" upgrade --install --create-namespace --namespace spark-k8s-operator --wait spark-k8s-operator ./target/charts/spark-k8s-operator-$$(VERSION).tgz
+	@echo "Running chainsaw e2e tests..."
+	$(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+
 .PHONY: cleanup-chainsaw-e2e
 cleanup-chainsaw-e2e: ## Run the chainsaw cleanup
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(MAKE) undeploy

--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ chainsaw-e2e: ## Run the chainsaw e2e tests
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
 
 .PHONY: chart-e2e
-chart-e2e: setup-chainsaw-cluster docker-build helm-chart-package ## Run chart e2e tests (deploy via Helm, then run chainsaw)
+chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package ## Run chart e2e tests (deploy via Helm, then run chainsaw)
 	"$(KIND)" --name $(CHAINSAW_CLUSTER) load docker-image "$(IMG)"
 	@echo "Installing spark-k8s-operator chart..."
 	"$(HELM)" upgrade --install --create-namespace --namespace spark-k8s-operator --kubeconfig $(CHAINSAW_KUBECONFIG) --wait spark-k8s-operator ./target/charts/spark-k8s-operator-$(VERSION).tgz

--- a/Makefile
+++ b/Makefile
@@ -344,19 +344,12 @@ chainsaw-e2e: ## Run the chainsaw e2e tests
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
 
 .PHONY: chart-e2e
-chart-e2e: ## Run chart e2e tests (deploy via Helm, then run chainsaw)
-	@echo "Building Helm chart..."
-	$(MAKE) helm-chart-package
-	@echo "Installing operator dependencies..."
-	@if [ -n "$(strip $(OPERATOR_DEPENDS))" ]; then \
-		for dep in $(OPERATOR_DEPENDS); do \
-			"$(HELM)" upgrade --install --create-namespace --namespace kubedoop-operators --wait $$dep oci://quay.io/kubedoopcharts/$$dep --version $(VERSION); \
-		done; \
-	fi
+chart-e2e: setup-chainsaw-cluster docker-build helm-chart-package ## Run chart e2e tests (deploy via Helm, then run chainsaw)
+	"$(KIND)" --name $(CHAINSAW_CLUSTER) load docker-image "$(IMG)"
 	@echo "Installing spark-k8s-operator chart..."
-	"$(HELM)" upgrade --install --create-namespace --namespace spark-k8s-operator --wait spark-k8s-operator ./target/charts/spark-k8s-operator-$(VERSION).tgz
+	"$(HELM)" upgrade --install --create-namespace --namespace spark-k8s-operator --kubeconfig $(CHAINSAW_KUBECONFIG) --wait spark-k8s-operator ./target/charts/spark-k8s-operator-$(VERSION).tgz
 	@echo "Running chainsaw e2e tests..."
-	$(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
 
 .PHONY: cleanup-chainsaw-e2e
 cleanup-chainsaw-e2e: ## Run the chainsaw cleanup

--- a/Makefile
+++ b/Makefile
@@ -350,11 +350,11 @@ chart-e2e: ## Run chart e2e tests (deploy via Helm, then run chainsaw)
 	@echo "Installing operator dependencies..."
 	@if [ -n "$(strip $(OPERATOR_DEPENDS))" ]; then \
 		for dep in $(OPERATOR_DEPENDS); do \
-			"$(HELM)" upgrade --install --create-namespace --namespace kubedoop-operators --wait $$dep oci://quay.io/kubedoopcharts/$$dep --version $$(VERSION); \
+			"$(HELM)" upgrade --install --create-namespace --namespace kubedoop-operators --wait $$dep oci://quay.io/kubedoopcharts/$$dep --version $(VERSION); \
 		done; \
 	fi
 	@echo "Installing spark-k8s-operator chart..."
-	"$(HELM)" upgrade --install --create-namespace --namespace spark-k8s-operator --wait spark-k8s-operator ./target/charts/spark-k8s-operator-$$(VERSION).tgz
+	"$(HELM)" upgrade --install --create-namespace --namespace spark-k8s-operator --wait spark-k8s-operator ./target/charts/spark-k8s-operator-$(VERSION).tgz
 	@echo "Running chainsaw e2e tests..."
 	$(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
 


### PR DESCRIPTION
- Split chart-lint-test job into chart-lint-helm (ct lint + install) and chart-e2e (chainsaw e2e via Helm chart deployment) in both chart-lint-test.yml and release.yml
- Add -dev tag filtering logic in release.yml commit range detection
- Fix kind cluster name: remove cluster_name override, use default 'chart-testing' consistently
- Add Setup Go and Build image as independent steps in chart-lint-helm
- Add chart-e2e Makefile target with --config
- Upgrade GitHub Actions: checkout@v6, setup-go@v6, setup-helm@v5, setup-python@v6, kind-action@v1.14.0, chart-testing-action@v2.8.0, docker/login-action@v4