### PR TITLE
fix(e2e): replace bash-specific [[ with POSIX [ for /bin/sh compatibility

### DIFF
--- a/test/e2e/smoke/observability/chainsaw-test.yaml
+++ b/test/e2e/smoke/observability/chainsaw-test.yaml
@@ -67,7 +67,7 @@ spec:
 
               # Test metrics endpoint accessibility
               HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:18081/metrics)
-              if [[ "$HTTP_CODE" != "200" ]]; then
+              if [ "$HTTP_CODE" != "200" ]; then
                 echo "ERROR: Failed to access metrics endpoint, HTTP code: $HTTP_CODE"
                 kill $PF_PID 2>/dev/null || true
                 exit 1


### PR DESCRIPTION
The chainsaw e2e test uses `/bin/sh` which does not support bash-specific `[[` syntax.
Replace with POSIX-compatible `[` for shell portability.