### PR TITLE
fix(ci): align product-version matrix with zncdata-containers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           '1.34.3',
           '1.35.0'
         ]
-        product-version: ['3.5.2','3.5.5']
+        product-version: ['3.5.5']
     steps:
       - name: Clone the code
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           # '1.34.3',
           '1.35.0'
         ]
-        product-version: ['3.5.2','3.5.5']
+        product-version: ['3.5.5']
     steps:
       - name: Clone the code
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Remove `3.5.2` from `product-version` matrix in both `release.yml` and `test.yml`, as the corresponding product image `spark-k8s:3.5.2-kubedoop0.4.0-dev` does not exist in quay.io.

## Root Cause

The chainsaw-e2e matrix in release.yml includes `product-version: ['3.5.2','3.5.5']`, but `zncdata-containers/spark-k8s/versions.yaml` only publishes `3.5.5`. This causes `ErrImagePull` on all K8s versions when `PRODUCT_VERSION=3.5.2`.

## Files Changed

- `.github/workflows/release.yml` — `product-version: ['3.5.2','3.5.5']` → `['3.5.5']`
- `.github/workflows/test.yml` — `product-version: ['3.5.2','3.5.5']` → `['3.5.5']`