### PR TITLE
fix(e2e): honor PRODUCT_VERSION in chainsaw values and test manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,3 @@ cover.out
 # helm package directory
 target
 .worktree/
-
-# generated chainsaw values
-test/e2e/.values.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Binaries for programs and plugins
 *.exe
 *.exe~
@@ -51,3 +50,6 @@ cover.out
 # helm package directory
 target
 .worktree/
+
+# generated chainsaw values
+test/e2e/.values.yaml

--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ helm-chart-publish: helm-chart-package ## Publish helm chart for the operator.
 ##@ Chainsaw E2E
 
 CHAINSAW ?= $(LOCALBIN)/chainsaw
-CHAINSAW_VERSION ?= v0.2.15
+CHAINSAW_VERSION ?= v0.2.14
 CHAINSAW_CLUSTER ?= chainsaw-${PROJECT_NAME}
 CHAINSAW_KUBECONFIG ?= .kubeconfig
 # KIND_K8S_VERSION refers to the version of Kubernetes to be used by kind node image.

--- a/Makefile
+++ b/Makefile
@@ -291,13 +291,9 @@ helm-chart-publish: helm-chart-package ## Publish helm chart for the operator.
 ##@ Chainsaw E2E
 
 CHAINSAW ?= $(LOCALBIN)/chainsaw
-CHAINSAW_VERSION ?= v0.2.13
+CHAINSAW_VERSION ?= v0.2.15
 CHAINSAW_CLUSTER ?= chainsaw-${PROJECT_NAME}
 CHAINSAW_KUBECONFIG ?= .kubeconfig
-# Chainsaw only resolves ($values.*) bindings from files passed via --values,
-# so the product version selected by the CI matrix must be written to a values
-# file before running the tests. See the chainsaw-values target.
-CHAINSAW_VALUES ?= test/e2e/.values.yaml
 # KIND_K8S_VERSION refers to the version of Kubernetes to be used by kind node image.
 # The version only effects e2e tests.
 # When run `kind create --image kindest/node:v${KIND_K8S_VERSION}`, the node image version of k8s will be used to create the kind cluster,
@@ -343,13 +339,9 @@ setup-chainsaw-e2e: chainsaw docker-build ## Run the chainsaw setup
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(MAKE) deploy
 
 
-.PHONY: chainsaw-values
-chainsaw-values: ## Generate the chainsaw values file from PRODUCT_VERSION. When unset, null lets the operator default apply.
-	@echo "product_version: $${PRODUCT_VERSION:-null}" > $(CHAINSAW_VALUES)
-
 .PHONY: chainsaw-e2e
-chainsaw-e2e: chainsaw-values ## Run the chainsaw e2e tests
-	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --values $(CHAINSAW_VALUES)
+chainsaw-e2e: ## Run the chainsaw e2e tests
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --set product_version=$(PRODUCT_VERSION)
 
 .PHONY: chart-e2e
 chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package ## Run chart e2e tests (deploy via Helm, then run chainsaw)

--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,10 @@ CHAINSAW ?= $(LOCALBIN)/chainsaw
 CHAINSAW_VERSION ?= v0.2.13
 CHAINSAW_CLUSTER ?= chainsaw-${PROJECT_NAME}
 CHAINSAW_KUBECONFIG ?= .kubeconfig
+# Chainsaw only resolves ($values.*) bindings from files passed via --values,
+# so the product version selected by the CI matrix must be written to a values
+# file before running the tests. See the chainsaw-values target.
+CHAINSAW_VALUES ?= test/e2e/.values.yaml
 # KIND_K8S_VERSION refers to the version of Kubernetes to be used by kind node image.
 # The version only effects e2e tests.
 # When run `kind create --image kindest/node:v${KIND_K8S_VERSION}`, the node image version of k8s will be used to create the kind cluster,
@@ -339,9 +343,13 @@ setup-chainsaw-e2e: chainsaw docker-build ## Run the chainsaw setup
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(MAKE) deploy
 
 
+.PHONY: chainsaw-values
+chainsaw-values: ## Generate the chainsaw values file from PRODUCT_VERSION. When unset, null lets the operator default apply.
+	@echo "product_version: $${PRODUCT_VERSION:-null}" > $(CHAINSAW_VALUES)
+
 .PHONY: chainsaw-e2e
-chainsaw-e2e: ## Run the chainsaw e2e tests
-	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+chainsaw-e2e: chainsaw-values ## Run the chainsaw e2e tests
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --values $(CHAINSAW_VALUES)
 
 .PHONY: chart-e2e
 chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package ## Run chart e2e tests (deploy via Helm, then run chainsaw)

--- a/test/e2e/logging/chainsaw-test.yaml
+++ b/test/e2e/logging/chainsaw-test.yaml
@@ -7,6 +7,8 @@ spec:
     assert: 6000s
     exec: 6000s
   bindings:
+  - name: spark_version
+    value: ($values.product_version)
   - name: SPARK_MINIO_USER
     value: spark
   - name: SPARK_MINIO_PASSWORD
@@ -14,17 +16,6 @@ spec:
   - name: SPARK_MINIO_BUCKET
     value: spark-history
   steps:
-  # - name: foo
-  #   try:
-  #   - script:
-  #       env:
-  #         - name: product_version
-  #           value: (env('PRODUCT_VERSION'))
-  #       content: echo "product_version is $product_version"
-  #   - apply:
-  #       file: sparkhistoryserver.yaml
-  #   - assert:
-  #       file: sparkhistoryserver-assert.yaml
   - name: install minio
     try:
     - apply:

--- a/test/e2e/logging/sparkhistoryserver.yaml
+++ b/test/e2e/logging/sparkhistoryserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sparkhistory
 spec:
   image:
-    productVersion: 3.5.5
+    productVersion: ($values.product_version)
   clusterConfig:
     listenerClass: cluster-internal
     logFileDirectory:

--- a/test/e2e/oidc/chainsaw-test.yaml
+++ b/test/e2e/oidc/chainsaw-test.yaml
@@ -4,6 +4,8 @@ metadata:
   name: oidc
 spec:
   bindings:
+  - name: spark_version
+    value: ($values.product_version)
   - name: SPARK_MINIO_USER
     value: spark
   - name: SPARK_MINIO_PASSWORD

--- a/test/e2e/oidc/sparkhistoryserver.yaml
+++ b/test/e2e/oidc/sparkhistoryserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sparkhistory
 spec:
   image:
-    productVersion: (env('PRODUCT_VERSION'))
+    productVersion: ($values.product_version)
   clusterConfig:
     listenerClass: cluster-internal
     authentication:

--- a/test/e2e/smoke/cluster-operation/chainsaw-test.yaml
+++ b/test/e2e/smoke/cluster-operation/chainsaw-test.yaml
@@ -4,6 +4,8 @@ metadata:
   name: smoke-cluster-operation
 spec:
   bindings:
+  - name: spark_version
+    value: ($values.product_version)
   - name: SPARK_MINIO_USER
     value: spark
   - name: SPARK_MINIO_PASSWORD

--- a/test/e2e/smoke/cluster-operation/sparkhistoryserver.yaml
+++ b/test/e2e/smoke/cluster-operation/sparkhistoryserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-sparkhistoryserver
 spec:
   image:
-    productVersion: (env('PRODUCT_VERSION'))
+    productVersion: ($values.product_version)
   clusterOperation:
     reconciliationPaused: ($cluster_paused)
     stopped: ($cluster_stopped)

--- a/test/e2e/smoke/observability/chainsaw-test.yaml
+++ b/test/e2e/smoke/observability/chainsaw-test.yaml
@@ -4,6 +4,8 @@ metadata:
   name: smoke-observability
 spec:
   bindings:
+  - name: spark_version
+    value: ($values.product_version)
   - name: SPARK_MINIO_USER
     value: spark
   - name: SPARK_MINIO_PASSWORD

--- a/test/e2e/smoke/override-pdb/chainsaw-test.yaml
+++ b/test/e2e/smoke/override-pdb/chainsaw-test.yaml
@@ -4,6 +4,8 @@ metadata:
   name: smoke-override-pdb
 spec:
   bindings:
+  - name: spark_version
+    value: ($values.product_version)
   - name: SPARK_MINIO_USER
     value: spark
   - name: SPARK_MINIO_PASSWORD

--- a/test/e2e/smoke/override-pdb/sparkhistoryserver.yaml
+++ b/test/e2e/smoke/override-pdb/sparkhistoryserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-sparkhistoryserver
 spec:
   image:
-    productVersion: (env('PRODUCT_VERSION'))
+    productVersion: ($values.product_version)
   clusterConfig:
     listenerClass: cluster-internal
     logFileDirectory:

--- a/test/e2e/smoke/submit-task/chainsaw-test.yaml
+++ b/test/e2e/smoke/submit-task/chainsaw-test.yaml
@@ -4,6 +4,8 @@ metadata:
   name: submit-task
 spec:
   bindings:
+  - name: spark_version
+    value: ($values.product_version)
   - name: SPARK_MINIO_USER
     value: spark
   - name: SPARK_MINIO_PASSWORD

--- a/test/e2e/smoke/submit-task/sparkhistoryserver.yaml
+++ b/test/e2e/smoke/submit-task/sparkhistoryserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-sparkhistoryserver
 spec:
   image:
-    productVersion: (env('PRODUCT_VERSION'))
+    productVersion: ($values.product_version)
   clusterConfig:
     listenerClass: cluster-internal
     logFileDirectory:


### PR DESCRIPTION
## Problem

The chainsaw e2e product-version matrix is dead, for two stacked reasons:

1. CI (`test.yml` / `release.yml`) sets a `PRODUCT_VERSION` env var per matrix leg, but chainsaw only populates `$values` from `--values` files and the `chainsaw-e2e` Makefile target never passed one — so `($values.product_version)` in the observability manifest always resolved to `null`.
2. The other `SparkHistoryServer` manifests read `(env('PRODUCT_VERSION'))` directly (which bypasses the values mechanism and breaks local runs where the variable is unset), and the logging manifest pinned a fixed version.

Net effect: the matrix legs (3.5.2, 3.5.5) did not reliably test what CI requested. (A third link in the chain — `GetImage()` dropping `spec.image.productVersion` — was already fixed on main by #263.)

## Fix

- Add a `chainsaw-values` Makefile target that generates `test/e2e/.values.yaml` from `$PRODUCT_VERSION` (writes `product_version: null` when unset, preserving the default fallback for local runs), pass `--values` in `chainsaw-e2e`, and gitignore the generated file.
- Point all six e2e `SparkHistoryServer` manifests at `($values.product_version)`, with a `spark_version` binding per chainsaw-test.yaml (same pattern as zookeeper-operator). This replaces the `env()` lookups and the hardcoded pin in logging, and drops a dead commented-out debug step there.

## Verification

Verified live in a kind cluster before the rebase onto current main: ran the `smoke/override-pdb` suite with `PRODUCT_VERSION=3.5.2` (the non-default matrix leg) — the applied CR carried `productVersion: "3.5.2"` and the StatefulSet ran `quay.io/zncdatadev/spark-k8s:3.5.2-kubedoop0.0.0-dev`, confirming the values → CR → StatefulSet image chain end to end; the suite passed. The CI matrix on this PR re-runs both legs on top of #263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)